### PR TITLE
Allow wasm execution through CSP.

### DIFF
--- a/lib/CSPSetter.php
+++ b/lib/CSPSetter.php
@@ -68,6 +68,7 @@ class CSPSetter implements IEventListener {
 		if (!empty($apiServer)) {
 			$csp->addAllowedChildSrcDomain($apiServer);
 			$csp->addAllowedConnectDomain($apiServer);
+			$csp->addAllowedFontDomain($apiServer);
 			$csp->addAllowedScriptDomain($apiServer);
 			$csp->addAllowedWorkerSrcDomain($apiServer);
 		}
@@ -76,6 +77,7 @@ class CSPSetter implements IEventListener {
 		if (!empty($webServer) && $apiServer !== $webServer) {
 			$csp->addAllowedChildSrcDomain($webServer);
 			$csp->addAllowedConnectDomain($webServer);
+			$csp->addAllowedFontDomain($webServer);
 			$csp->addAllowedScriptDomain($webServer);
 			$csp->addAllowedWorkerSrcDomain($webServer);
 		}

--- a/lib/CSPSetter.php
+++ b/lib/CSPSetter.php
@@ -62,6 +62,7 @@ class CSPSetter implements IEventListener {
 		$csp->addAllowedScriptDomain("'self'");
 		$csp->addAllowedWorkerSrcDomain('blob:');
 		$csp->addAllowedWorkerSrcDomain("'self'");
+		$csp->addAllowedScriptDomain("'wasm-unsafe-eval'");
 
 		$apiServer = $this->config->getApiServer();
 		if (!empty($apiServer)) {


### PR DESCRIPTION
This is necessary to support all new features of pdf.js 5.x in the backend.