### PR TITLE
Don't try to verify files in the background that are too large.

### DIFF
--- a/lib/BackgroundJob/BackgroundVerify.php
+++ b/lib/BackgroundJob/BackgroundVerify.php
@@ -168,6 +168,8 @@ class BackgroundVerify extends TimedJob {
 		$since->setTimezone(new \DateTimeZone('UTC'));
 		$since = $since->sub(new \DateInterval('PT' . self::VERIFY_ERROR_DELAY_MINUTES . 'M'));
 
+		$maxSize = $this->config->getMaxBackgroundVerifySize();
+
 		$query = $this->db->getQueryBuilder();
 		$query->select('fc.fileid', 'storage')
 			->from('filecache', 'fc')
@@ -176,6 +178,7 @@ class BackgroundVerify extends TimedJob {
 			->where($query->expr()->isNull('fs.file_id'))
 			->andWhere($query->expr()->eq('mimetype', $query->expr()->literal($pdfMimeTypeId)))
 			->andWhere($query->expr()->like('path', $query->expr()->literal('files/%')))
+			->andWhere($query->expr()->lte('size', $query->createNamedParameter($maxSize)))
 			->andWhere(
 				$query->expr()->orX(
 					$query->expr()->isNull('vf.updated'),

--- a/lib/Config.php
+++ b/lib/Config.php
@@ -38,6 +38,7 @@ class Config {
 	public const DEFAULT_WEB_SERVER = 'https://www.certificate24.com/';
 	public const DEFAULT_REQUEST_TIMEOUT = '300';
 	public const DEFAULT_SAVE_MODE = 'new';
+	public const DEFAULT_MAX_BACKGROUND_VERIFY_SIZE = '268435456';  // 256 MBytes
 
 	private IConfig $config;
 	protected IAppData $appData;
@@ -162,6 +163,15 @@ class Config {
 		$value = $this->config->getAppValue(self::APP_ID, 'delete_max_age', '30');
 		if ($value === null || $value === '') {
 			$value = '30';
+		}
+
+		return (int)$value;
+	}
+
+	public function getMaxBackgroundVerifySize(): int {
+		$value = $this->config->getAppValue(self::APP_ID, 'max_background_verify_size', self::DEFAULT_MAX_BACKGROUND_VERIFY_SIZE);
+		if ($value === null || $value === '') {
+			$value = self::DEFAULT_MAX_BACKGROUND_VERIFY_SIZE;
 		}
 
 		return (int)$value;

--- a/tests/php/VerifyTest.php
+++ b/tests/php/VerifyTest.php
@@ -22,6 +22,7 @@
  */
 namespace OCA\Certificate24\Tests\php;
 
+use OCA\Certificate24\Config;
 use OCA\Certificate24\Requests;
 use OCA\Certificate24\Verify;
 use OCP\AppFramework\Utility\ITimeFactory;
@@ -47,9 +48,10 @@ class VerifyTest extends TestCase {
 		$db = \OC::$server->query(IDBConnection::class);
 		$mimeTypeLoader = \OC::$server->query(IMimeTypeLoader::class);
 		$logger = $this->createMock(LoggerInterface::class);
+		$config = $this->createMock(Config::class);
 		$requests = $this->createMock(Requests::class);
 
-		$this->verify = new Verify($logger, $db, $mimeTypeLoader, $requests);
+		$this->verify = new Verify($logger, $db, $mimeTypeLoader, $config, $requests);
 		$this->verify->deleteAllFileSignatures();
 		$this->verify->deleteAllFailed();
 	}


### PR DESCRIPTION
Default limit is 256 MBytes, can be changed through app config value `max_background_verify_size`.

Resolves #492 